### PR TITLE
Fix display of offer boxes on desktop

### DIFF
--- a/assets/built/screen.css
+++ b/assets/built/screen.css
@@ -2979,11 +2979,43 @@ body[class*=" gh-font-heading"]:not(.gh-font-heading-fira-sans):not(.gh-font-hea
 
 /* Course Boxes Optimization - Modern Card Design */
 .gh-course-boxes {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    display: grid !important;
+    grid-template-columns: repeat(3, 1fr) !important;
     gap: 2rem;
     margin-top: 0;
     margin-bottom: 4rem;
+}
+
+/* Force display grid on desktop to override any conflicting .gh-feed rules */
+@media (min-width: 1024px) {
+    .gh-feed.gh-course-boxes {
+        display: grid !important;
+        grid-template-columns: repeat(3, 1fr) !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+    }
+}
+
+/* Ensure the container section is visible */
+section:has(.gh-course-boxes) {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+}
+
+/* Alternative for browsers without :has() support */
+.gh-container.gh-outer,
+.gh-container-inner.gh-inner {
+    display: block !important;
+    visibility: visible !important;
+}
+
+/* Specific rule for course boxes container */
+.gh-container:has(.gh-course-boxes),
+.gh-container-inner:has(.gh-course-boxes) {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
 }
 
 /* Course Box Cards */
@@ -2995,6 +3027,9 @@ body[class*=" gh-font-heading"]:not(.gh-font-heading-fira-sans):not(.gh-font-hea
     transition: all 0.3s ease;
     overflow: hidden;
     height: 100%;
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
 }
 
 .gh-course-boxes .gh-card:hover {

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -2949,11 +2949,43 @@ body[class*=" gh-font-heading"]:not(.gh-font-heading-fira-sans):not(.gh-font-hea
 
 /* Course Boxes Optimization - Modern Card Design */
 .gh-course-boxes {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    display: grid !important;
+    grid-template-columns: repeat(3, 1fr) !important;
     gap: 2rem;
     margin-top: 0;
     margin-bottom: 4rem;
+}
+
+/* Force display grid on desktop to override any conflicting .gh-feed rules */
+@media (min-width: 1024px) {
+    .gh-feed.gh-course-boxes {
+        display: grid !important;
+        grid-template-columns: repeat(3, 1fr) !important;
+        visibility: visible !important;
+        opacity: 1 !important;
+    }
+}
+
+/* Ensure the container section is visible */
+section:has(.gh-course-boxes) {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+}
+
+/* Alternative for browsers without :has() support */
+.gh-container.gh-outer,
+.gh-container-inner.gh-inner {
+    display: block !important;
+    visibility: visible !important;
+}
+
+/* Specific rule for course boxes container */
+.gh-container:has(.gh-course-boxes),
+.gh-container-inner:has(.gh-course-boxes) {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
 }
 
 /* Course Box Cards */
@@ -2965,6 +2997,9 @@ body[class*=" gh-font-heading"]:not(.gh-font-heading-fira-sans):not(.gh-font-hea
     transition: all 0.3s ease;
     overflow: hidden;
     height: 100%;
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
 }
 
 .gh-course-boxes .gh-card:hover {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure course boxes are visible on desktop by adjusting CSS display and visibility rules.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the three course boxes (`.gh-course-boxes`) were only visible in mobile view, appearing as vertical lines on larger screens. This PR adds specific CSS rules with `!important` and media queries to force their `display: grid`, `visibility: visible`, and `opacity: 1` on desktop, resolving the display issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-dd3ffd2a-4a0d-49c1-b281-c85526093600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dd3ffd2a-4a0d-49c1-b281-c85526093600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>